### PR TITLE
General Shopping List

### DIFF
--- a/app/assets/stylesheets/foods.css
+++ b/app/assets/stylesheets/foods.css
@@ -40,6 +40,7 @@ tbody td {
 
 #foods-index td .btn {
   background-color: unset;
+  border: none;
 }
 
 #new-food,

--- a/app/assets/stylesheets/general_shopping_lists.css
+++ b/app/assets/stylesheets/general_shopping_lists.css
@@ -1,0 +1,9 @@
+#shopping-list {
+  align-items: center;
+  gap: 24px;
+}
+
+.summary {
+  display: flex;
+  gap: 16px;
+}

--- a/app/controllers/general_shopping_lists_controller.rb
+++ b/app/controllers/general_shopping_lists_controller.rb
@@ -1,0 +1,18 @@
+class GeneralShoppingListsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @foods = Food.joins(recipe_foods: :recipe).where(['recipes.user_id != ?', current_user.id]).map do |food|
+      total_quantity = food.recipe_foods.sum(:quantity)
+
+      {
+        name: food.name,
+        total_quantity:,
+        measurement_unit: food.measurement_unit,
+        price: total_quantity * food.unit_price
+      }
+    end
+
+    @total_price = @foods.reduce(0) { |sum, food| sum + food[:price] }
+  end
+end

--- a/app/controllers/general_shopping_lists_controller.rb
+++ b/app/controllers/general_shopping_lists_controller.rb
@@ -2,17 +2,20 @@ class GeneralShoppingListsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @foods = Food.joins(recipe_foods: :recipe).where(['recipes.user_id != ?', current_user.id]).map do |food|
+    @total_price = 0
+    @foods = current_user.foods.includes(:recipe_foods).map do |food|
+      next if food.recipe_foods.empty?
+
       total_quantity = food.recipe_foods.sum(:quantity)
+      price = total_quantity * food.unit_price
+      @total_price += price
 
       {
         name: food.name,
         total_quantity:,
         measurement_unit: food.measurement_unit,
-        price: total_quantity * food.unit_price
+        price:
       }
-    end
-
-    @total_price = @foods.reduce(0) { |sum, food| sum + food[:price] }
+    end.compact
   end
 end

--- a/app/controllers/public_recipes_controller.rb
+++ b/app/controllers/public_recipes_controller.rb
@@ -1,6 +1,6 @@
 class PublicRecipesController < ApplicationController
   def index
-    @recipes = Recipe.includes(:user, recipe_foods: [:food]).where(public: true)
+    @recipes = Recipe.includes(:user, recipe_foods: [:food]).where(public: true).order(created_at: :desc)
   end
 
   def show

--- a/app/views/general_shopping_lists/index.html.erb
+++ b/app/views/general_shopping_lists/index.html.erb
@@ -1,0 +1,28 @@
+<section id="shopping-list" class="flex-col">
+  <h2>Shopping List</h2>
+
+  <div class="summary">
+    <h3>Amount of food items to buy: <%= @foods.length %></h3>
+    <h3>
+      Total value of food needed: $<%= number_with_precision(@total_price, precision: 2) %>
+    </h3>
+  </div>
+  <table class="ingredients-table">
+    <thead>
+      <tr>
+        <th>Food</th>
+        <th>Quantity</th>
+        <th>Price</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @foods.each do |food| %>
+        <tr>
+          <td class="food-name"><%= food[:name] %></td>
+          <td><%= "#{food[:total_quantity]}""#{food[:measurement_unit]}" %></td>
+          <td>$<%= number_with_precision(food[:price], precision: 2) %></td> 
+        </tr>
+      <% end %>    
+    </tbody>
+  </table>
+</section>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div class="recipe-btn-container">
-      <%= link_to 'Generate shopping list', general_shopping_list_index_path, class: 'recipe-create-btn' %>
+      <%= link_to 'Generate shopping list', general_shopping_lists_path, class: 'recipe-create-btn' %>
       <%= link_to 'Add ingredient', new_recipe_recipe_food_path(@recipe), data: { turbo_frame: 'add-ingredient'  },
                   class: 'recipe-create-btn' %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :recipe_foods, except: %i[show]
   end
   resources :public_recipes, only: %i[index show]
-  resources :general_shopping_list, only: %i[index]
+  resources :general_shopping_lists, only: %i[index], path: '/general_shopping_list'
 
   get '/users', to: 'recipes#index'
 

--- a/spec/system/general_shopping_lists/index_spec.rb
+++ b/spec/system/general_shopping_lists/index_spec.rb
@@ -3,28 +3,25 @@ require 'rails_helper'
 RSpec.describe 'Public Recipes #index', type: :system do
   subject do
     test_user = User.create(name: 'Tom', email: 'tom@example.com', password: 'password')
-    Food.create(user: test_user, name: 'test_user food not used', measurement_unit: 'L', unit_price: 2)
-    corn = Food.create(user: test_user, name: 'corn', measurement_unit: 'kg', unit_price: 4)
-    soda = Food.create(user: test_user, name: 'soda', measurement_unit: 'l', unit_price: 3)
+    test_user_food = Food.create(user: test_user, name: 'test_user food', measurement_unit: 'L', unit_price: 2)
     test_recipe = Recipe.create(user: test_user, name: 'test recipe', preparation_time: '3min', cooking_time: '1min',
                                 description: 'test2')
-    RecipeFood.create(quantity: 2, food: corn, recipe: test_recipe)
-    RecipeFood.create(quantity: 3, food: soda, recipe: test_recipe)
-
-    test_user_two = User.create(name: 'Lisa', email: 'lisa@example.com', password: 'password')
-    Food.create(user: test_user_two, name: 'test_user_two food not used', measurement_unit: 'L', unit_price: 2)
-    rice = Food.create(user: test_user_two, name: 'rice', measurement_unit: 'kg', unit_price: 3)
-    milk = Food.create(user: test_user_two, name: 'milk', measurement_unit: 'l', unit_price: 1)
-    test_recipe2 = Recipe.create(user: test_user_two, name: 'test recipe', preparation_time: '3min',
-                                 cooking_time: '1min', description: 'test2')
-    RecipeFood.create(quantity: 2, food: rice, recipe: test_recipe2)
-    RecipeFood.create(quantity: 3, food: milk, recipe: test_recipe2)
+    RecipeFood.create(quantity: 2, food: test_user_food, recipe: test_recipe)
 
     @user = User.create(name: 'Maria', email: 'maria@example.com', password: 'password')
+
     egg = Food.create(user: @user, name: 'egg', measurement_unit: 'units', unit_price: 10.5)
-    user_recipe = Recipe.create(user: @user, name: 'public recipe', preparation_time: '2min',
-                                cooking_time: '5min', description: 'test')
-    RecipeFood.create(quantity: 2, food: egg, recipe: user_recipe)
+    milk = Food.create(user: @user, name: 'milk', measurement_unit: 'L', unit_price: 5)
+    Food.create(user: @user, name: 'food not used by user', measurement_unit: 'units', unit_price: 2)
+
+    user_recipe1 = Recipe.create(user: @user, name: 'public recipe', preparation_time: '2min',
+                                 cooking_time: '5min', description: 'test')
+    RecipeFood.create(quantity: 3, food: egg, recipe: user_recipe1)
+    RecipeFood.create(quantity: 3, food: milk, recipe: user_recipe1)
+
+    user_recipe2 = Recipe.create(user: @user, name: 'public recipe', preparation_time: '2min',
+                                 cooking_time: '5min', description: 'test')
+    RecipeFood.create(quantity: 4, food: milk, recipe: user_recipe2)
 
     visit new_user_session_path
     within('#new_user') do
@@ -44,53 +41,40 @@ RSpec.describe 'Public Recipes #index', type: :system do
     expect(page).to have_content('Price')
   end
 
-  it "should not display foods from the current user and the ones that other users created but didn't used them" do
+  it 'should not display foods from other users' do
     subject
     visit general_shopping_lists_path
 
-    expect(page).to_not have_content('egg')
-    expect(page).to_not have_content('test_user food not used')
-    expect(page).to_not have_content('test_user_two food not used')
+    expect(page).to_not have_content('test_user food')
+  end
+
+  it 'should not display foods that have not been used' do
+    subject
+    visit general_shopping_lists_path
+
+    expect(page).to_not have_content('food not used by user')
   end
 
   it 'should display the correct amount of food items' do
     subject
     visit general_shopping_lists_path
 
-    expect(page).to have_content('Amount of food items to buy: 4')
+    expect(page).to have_content('Amount of food items to buy: 2')
   end
 
   it 'should display the correct total price' do
     subject
     visit general_shopping_lists_path
 
-    expect(page).to have_content('Total value of food needed: $26.00')
+    expect(page).to have_content('Total value of food needed: $66.50')
   end
 
-  context 'corn' do
+  context 'egg' do
     it 'should be displayed its name, quantity and price' do
       subject
       visit general_shopping_lists_path
 
-      expect(page).to have_content('corn 2kg $8.00')
-    end
-  end
-
-  context 'soda' do
-    it 'should be displayed its name, quantity and price' do
-      subject
-      visit general_shopping_lists_path
-
-      expect(page).to have_content('soda 3l $9.00')
-    end
-  end
-
-  context 'rice' do
-    it 'should be displayed its name, quantity and price' do
-      subject
-      visit general_shopping_lists_path
-
-      expect(page).to have_content('rice 2kg $6.00')
+      expect(page).to have_content('egg 3units $31.50')
     end
   end
 
@@ -99,7 +83,7 @@ RSpec.describe 'Public Recipes #index', type: :system do
       subject
       visit general_shopping_lists_path
 
-      expect(page).to have_content('milk 3l $3.00')
+      expect(page).to have_content('milk 7L $35.00')
     end
   end
 end

--- a/spec/system/general_shopping_lists/index_spec.rb
+++ b/spec/system/general_shopping_lists/index_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe 'Public Recipes #index', type: :system do
+  subject do
+    test_user = User.create(name: 'Tom', email: 'tom@example.com', password: 'password')
+    Food.create(user: test_user, name: 'test_user food not used', measurement_unit: 'L', unit_price: 2)
+    corn = Food.create(user: test_user, name: 'corn', measurement_unit: 'kg', unit_price: 4)
+    soda = Food.create(user: test_user, name: 'soda', measurement_unit: 'l', unit_price: 3)
+    test_recipe = Recipe.create(user: test_user, name: 'test recipe', preparation_time: '3min', cooking_time: '1min',
+                                description: 'test2')
+    RecipeFood.create(quantity: 2, food: corn, recipe: test_recipe)
+    RecipeFood.create(quantity: 3, food: soda, recipe: test_recipe)
+
+    test_user_two = User.create(name: 'Lisa', email: 'lisa@example.com', password: 'password')
+    Food.create(user: test_user_two, name: 'test_user_two food not used', measurement_unit: 'L', unit_price: 2)
+    rice = Food.create(user: test_user_two, name: 'rice', measurement_unit: 'kg', unit_price: 3)
+    milk = Food.create(user: test_user_two, name: 'milk', measurement_unit: 'l', unit_price: 1)
+    test_recipe2 = Recipe.create(user: test_user_two, name: 'test recipe', preparation_time: '3min',
+                                 cooking_time: '1min', description: 'test2')
+    RecipeFood.create(quantity: 2, food: rice, recipe: test_recipe2)
+    RecipeFood.create(quantity: 3, food: milk, recipe: test_recipe2)
+
+    @user = User.create(name: 'Maria', email: 'maria@example.com', password: 'password')
+    egg = Food.create(user: @user, name: 'egg', measurement_unit: 'units', unit_price: 10.5)
+    user_recipe = Recipe.create(user: @user, name: 'public recipe', preparation_time: '2min',
+                                cooking_time: '5min', description: 'test')
+    RecipeFood.create(quantity: 2, food: egg, recipe: user_recipe)
+
+    visit new_user_session_path
+    within('#new_user') do
+      fill_in 'Email', with: 'maria@example.com'
+      fill_in 'Password', with: 'password'
+    end
+
+    find_button('Log in').click
+  end
+
+  it 'should display table columns' do
+    subject
+    visit general_shopping_lists_path
+
+    expect(page).to have_content('Food')
+    expect(page).to have_content('Quantity')
+    expect(page).to have_content('Price')
+  end
+
+  it "should not display foods from the current user and the ones that other users created but didn't used them" do
+    subject
+    visit general_shopping_lists_path
+
+    expect(page).to_not have_content('egg')
+    expect(page).to_not have_content('test_user food not used')
+    expect(page).to_not have_content('test_user_two food not used')
+  end
+
+  it 'should display the correct amount of food items' do
+    subject
+    visit general_shopping_lists_path
+
+    expect(page).to have_content('Amount of food items to buy: 4')
+  end
+
+  it 'should display the correct total price' do
+    subject
+    visit general_shopping_lists_path
+
+    expect(page).to have_content('Total value of food needed: $26.00')
+  end
+
+  context 'corn' do
+    it 'should be displayed its name, quantity and price' do
+      subject
+      visit general_shopping_lists_path
+
+      expect(page).to have_content('corn 2kg $8.00')
+    end
+  end
+
+  context 'soda' do
+    it 'should be displayed its name, quantity and price' do
+      subject
+      visit general_shopping_lists_path
+
+      expect(page).to have_content('soda 3l $9.00')
+    end
+  end
+
+  context 'rice' do
+    it 'should be displayed its name, quantity and price' do
+      subject
+      visit general_shopping_lists_path
+
+      expect(page).to have_content('rice 2kg $6.00')
+    end
+  end
+
+  context 'milk' do
+    it 'should be displayed its name, quantity and price' do
+      subject
+      visit general_shopping_lists_path
+
+      expect(page).to have_content('milk 3l $3.00')
+    end
+  end
+end

--- a/spec/system/navbar_spec.rb
+++ b/spec/system/navbar_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe 'Navbar', type: :system do
   context 'user is not logged' do
     it 'should display only sign in and sign out' do
       visit root_path
-      expect(page).to have_content('Sign In')
-      expect(page).to have_content('Sign Up')
-      expect(page).to_not have_content('Foods')
-      expect(page).to_not have_content('Recipes')
-      expect(page).to_not have_content('My Profile')
-      expect(page).to_not have_content('Sign out')
+      expect(page).to have_link('Sign In')
+      expect(page).to have_link('Sign Up')
+      expect(page).to_not have_link('Foods')
+      expect(page).to_not have_link('Recipes')
+      expect(page).to_not have_link('My Profile')
+      expect(page).to_not have_button('Sign out')
     end
 
     it 'should redirect to sign in when clicking sign in' do
@@ -52,12 +52,12 @@ RSpec.describe 'Navbar', type: :system do
     it 'should display Foods, Recipes, My Profile, Sign Out' do
       subject
       visit root_path
-      expect(page).to_not have_content('Sign In')
-      expect(page).to_not have_content('Sign Up')
-      expect(page).to have_content('Foods')
-      expect(page).to have_content('Recipes')
-      expect(page).to have_content('My Profile')
-      expect(page).to have_content('Sign Out')
+      expect(page).to_not have_link('Sign In')
+      expect(page).to_not have_link('Sign Up')
+      expect(page).to have_link('Foods')
+      expect(page).to have_link('Recipes')
+      expect(page).to have_link('My Profile')
+      expect(page).to have_button('Sign Out')
     end
 
     it 'should redirect to log in when clicking the logo' do


### PR DESCRIPTION
## General Shopping List

In this milestone I:

- Added general shopping list view:
  - Should show the list of food that is missing for all recipes of the logged-in user.
  - Should count the total food items and total price of the missing food.

- Test created feature(s)
- Remove the Delete button's border from `/foods`
- Add order desc to Public Recipes Index